### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   release-cookbook:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# AppVeyor Deployment Agent Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Installs AppVeyor Agent & Triggers Deployment
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 - The AppVeyor deployment agent is Windows-only; this cookbook should only advertise and test Windows support.
 - Installation depends on the public MSI download endpoint at `https://www.appveyor.com/downloads/deployment-agent/<version>/AppveyorDeploymentAgent.msi`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,6 @@ Installs AppVeyor Agent & Triggers Deployment
 
 ## Known Limitations
 
-- The AppVeyor deployment agent is Windows-only; this cookbook should only advertise and test Windows support.
-- Installation depends on the public MSI download endpoint at `https://www.appveyor.com/downloads/deployment-agent/<version>/AppveyorDeploymentAgent.msi`.
-- The resource expects an AppVeyor deployment access key and deployment group at converge time.
+* The AppVeyor deployment agent is Windows-only; this cookbook should only advertise and test Windows support.
+* Installation depends on the public MSI download endpoint at `https://www.appveyor.com/downloads/deployment-agent/<version>/AppveyorDeploymentAgent.msi`.
+* The resource expects an AppVeyor deployment access key and deployment group at converge time.

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,0 @@
-source 'https://supermarket.chef.io'
-
-cookbook 'test', path: 'test/cookbooks/test'
-
-metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.2.12](https://github.com/sous-chefs/appveyor-ci/compare/v0.2.11...v0.2.12) (2026-03-22)
 
-
 ### Bug Fixes
 
 * **ci:** Update release workflow ([#71](https://github.com/sous-chefs/appveyor-ci/issues/71)) ([660220a](https://github.com/sous-chefs/appveyor-ci/commit/660220afd12867b079ac635db7b770888af3d0e9))
@@ -16,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Bug Fixes
 
-- **ci:** Update release workflow ([#71](https://github.com/sous-chefs/appveyor-ci/issues/71)) ([660220a](https://github.com/sous-chefs/appveyor-ci/commit/660220afd12867b079ac635db7b770888af3d0e9))
+* **ci:** Update release workflow ([#71](https://github.com/sous-chefs/appveyor-ci/issues/71)) ([660220a](https://github.com/sous-chefs/appveyor-ci/commit/660220afd12867b079ac635db7b770888af3d0e9))
 
 ## 0.2.10 - *2025-09-04*
 
@@ -32,37 +31,37 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 0.2.4 - *2023-03-02*
 
-- Add workflows
+* Add workflows
 
 ## 0.2.3 - *2023-03-01*
 
-- Update workflows to 2.0.1
-- Remove mdl and replace with markdownlint-cli2
-- Remove delivery folder
+* Update workflows to 2.0.1
+* Remove mdl and replace with markdownlint-cli2
+* Remove delivery folder
 
 ## 0.2.2 - *2021-08-29*
 
-- Standardise files with files in sous-chefs/repo-management
-- Add a `resource_name` in addition to provides in the resource
-- Fix `nodoc` option for gem
+* Standardise files with files in sous-chefs/repo-management
+* Add a `resource_name` in addition to provides in the resource
+* Fix `nodoc` option for gem
 
 ## 0.2.1 - 2020-06-02
 
-- resolved cookstyle error: resources/agent_install.rb:20:1 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`
+* resolved cookstyle error: resources/agent_install.rb:20:1 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`
 
 ## [0.2.0] - 2018-05-21
 
-- Move to the Sous-Chefs organization
-- Test with delivery
-- Use the `windows_package` resource instead of the package resource
+* Move to the Sous-Chefs organization
+* Test with delivery
+* Use the `windows_package` resource instead of the package resource
 
 ## [0.1.4] - 2016-10-11
 
-- Update Gem deps inline with Chefdk 0.18
-- Windows cookbook dep
-- Reg key creation in favour of agent switch
+* Update Gem deps inline with Chefdk 0.18
+* Windows cookbook dep
+* Reg key creation in favour of agent switch
 
 ## [0.1.3] - 2016-09-23
 
-- Uses HTTPS for download the agent
-- Kitchen testing in AppVeyor
+* Uses HTTPS for download the agent
+* Kitchen testing in AppVeyor

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'appveyor-ci'
+
+run_list 'test::default'
+
+cookbook 'appveyor-ci', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/documentation/appveyor-ci_appveyor_agent.md
+++ b/documentation/appveyor-ci_appveyor_agent.md
@@ -4,20 +4,24 @@ Installs the AppVeyor deployment agent MSI on Windows hosts.
 
 ## Actions
 
-| Action | Description |
-|--------|-------------|
+<!-- markdownlint-disable MD060 -->
+
+| Action     | Description                                      |
+| ---------- | ------------------------------------------------ |
 | `:install` | Installs the AppVeyor deployment agent (default). |
 
 ## Properties
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `version` | String | name property | AppVeyor deployment agent version to install. |
-| `access_key` | String | `nil` | Deployment access key used by the agent. |
-| `environment_access_key` | String | `nil` | Alias for `access_key` for compatibility with existing examples. |
-| `deployment_group` | String | required | AppVeyor deployment group name. |
-| `installer_url` | String | derived from `version` | Custom MSI download URL. |
-| `install_path` | String | `'C:\\Program Files (x86)\\AppVeyor\\DeploymentAgent\\Appveyor.DeploymentAgent.Service.exe'` | Expected installation path. |
+| Property                 | Type   | Default                                                                                         | Description                                                           |
+| ------------------------ | ------ | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `version`                | String | name property                                                                                   | AppVeyor deployment agent version to install.                         |
+| `access_key`             | String | `nil`                                                                                           | Deployment access key used by the agent.                              |
+| `environment_access_key` | String | `nil`                                                                                           | Alias for `access_key` for compatibility with existing examples.      |
+| `deployment_group`       | String | required                                                                                        | AppVeyor deployment group name.                                       |
+| `installer_url`          | String | derived from `version`                                                                          | Custom MSI download URL.                                              |
+| `install_path`           | String | `'C:\\Program Files (x86)\\AppVeyor\\DeploymentAgent\\Appveyor.DeploymentAgent.Service.exe'` | Expected installation path.                                           |
+
+<!-- markdownlint-enable MD060 -->
 
 ## Examples
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list